### PR TITLE
Add missing privapp permissions

### DIFF
--- a/privapp-permissions-microg.xml
+++ b/privapp-permissions-microg.xml
@@ -5,5 +5,10 @@
 <permissions>
     <privapp-permissions package="com.google.android.gms">
         <permission name="android.permission.INSTALL_LOCATION_PROVIDER"/>
+        <permission name="android.permission.ACCESS_COARSE_LOCATION"></permission>
+        <permission name="android.permission.ACCESS_COARSE_UPDATES"></permission>
+        <permission name="android.permission.RECEIVE_BOOT_COMPLETED"></permission>
+        <permission name="com.android.settings.INJECT_SETTINGS"></permission>
+        <permission name="org.microg.permission.FORCE_COARSE_LOCATION"></permission>
     </privapp-permissions>
 </permission>


### PR DESCRIPTION
Adds all the [permissions requested by the unifiednlp-base app](https://github.com/microg/android_packages_apps_UnifiedNlp/blob/master/unifiednlp-base/src/main/AndroidManifest.xml#L28).
Without these UnifiedNlp was misbehaving on Lineage 16. For instance, I could no longer turn on the WiFi.