### PR TITLE
Fix installation script for A/B system-as-root devices

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -25,6 +25,7 @@ WORK_FOLDER='microg'
 ZIP_FILE="$3"
 ADDOND='70-microg.sh'
 PRIVAPP_PERMISSIONS='privapp-permissions-microg.xml'
+SYSTEM="/system"
 
 cd /tmp
 mkdir $WORK_FOLDER
@@ -32,12 +33,18 @@ cd $WORK_FOLDER
 unzip -o "$ZIP_FILE"
 
 mount /system
-
+# A/B system-as-root devices have the actual system partition
+# mounted under /system/system when in the recovery.
+# Snippet taken from F-Droid Privileged Extension.
+system_as_root=`getprop ro.build.system_root_image`
+if [ "$system_as_root" == "true"  ]; then
+  SYSTEM="/system/system"
+fi
 
 echo -n -e 'ui_print Installing apps...\n' > /proc/self/fd/$2
 
 # Prepare work folder
-BUILD_VERSION_SDK="$(grep -F ro.build.version.sdk /system/build.prop)"
+BUILD_VERSION_SDK="$(grep -F ro.build.version.sdk ${SYSTEM}/build.prop)"
 BUILD_VERSION_SDK_INT="${BUILD_VERSION_SDK#*=}"
 if [ "${BUILD_VERSION_SDK_INT}" -ge 21 ]
 then # each apk has its own subdirectory in /system/priv-app or /system/app
@@ -68,20 +75,20 @@ echo "$TARGET_APKS" | xargs -n 1 rm -f
 echo "$TARGET_DIRS" | xargs -n 1 rm -rf
 
 # Copy new files and fix permissions
-cp -r system/* /system/
+cp -r system/* ${SYSTEM}/
 echo "$TARGET_APKS" | xargs -n 1 chmod 644
 echo "$TARGET_DIRS" | xargs -n 1 chmod 755
 
 
 echo -n -e 'ui_print Installing OTA survival script...\n' > /proc/self/fd/$2
 
-cp ${ADDOND} /system/addon.d/
+cp ${ADDOND} ${SYSTEM}/addon.d/
 
 if [ "${BUILD_VERSION_SDK_INT}" -ge 27 ]
 then # Android 8+ require an explicit permission whitelist file for privileged apps
   echo -n -e 'ui_print Whitelisting privapp permissions...\n' > /proc/self/fd/$2
 
-  cp ${PRIVAPP_PERMISSIONS} /system/etc/permissions/
+  cp ${PRIVAPP_PERMISSIONS} ${SYSTEM}/etc/permissions/
 fi
 
 echo -n -e 'ui_print done\n' > /proc/self/fd/$2

--- a/templates/addond-head
+++ b/templates/addond-head
@@ -1,5 +1,7 @@
 #!/sbin/sh
 #
+# ADDOND_VERSION=2
+#
 # /system/addon.d/70-microg.sh
 # During a system upgrade, this script backs up microG apps,
 # /system is formatted and reinstalled, then the files are restored.
@@ -9,4 +11,4 @@
 
 list_files() {
 cat <<EOF
-/etc/permissions/privapp-permissions-microg.xml
+etc/permissions/privapp-permissions-microg.xml


### PR DESCRIPTION
A/B system-as-root devices have the actual system partition mounted under `/system/system` when in the recovery.

This should fix both #11 and #12. Though, before closing those issues, we need input from @oscaropenness and @Br31zh to know if they are using A/B system-as-root devices.

Taken from
https://gitlab.com/fdroid/privileged-extension/commit/decd7f35ef64e8ec696d2a9feae38fd802479705