### PR TITLE
Manually check system as root layout for Android 10. Fix #11

### DIFF
--- a/META-INF/com/google/android/update-binary
+++ b/META-INF/com/google/android/update-binary
@@ -35,9 +35,14 @@ unzip -o "$ZIP_FILE"
 mount /system
 # A/B system-as-root devices have the actual system partition
 # mounted under /system/system when in the recovery.
-# Snippet taken from F-Droid Privileged Extension.
+# All Android 10 devices act as system-as-root devices.
 SYSTEM_AS_ROOT="$(getprop ro.build.system_root_image)"
-if [ "$SYSTEM_AS_ROOT" == "true"  ]; then
+if [ "$SYSTEM_AS_ROOT" == "true" ]
+then # we are on an Android Pie device with A/B system-as-root layout
+  SYSTEM_ROOT="/system/system"
+elif [ -f "/system/system/build.prop" ]
+then # we are on an Android 10 device
+  SYSTEM_AS_ROOT="true"
   SYSTEM_ROOT="/system/system"
 fi
 


### PR DESCRIPTION
[Hopefully fixes #11]

Android 10 devices don't set `ro.build.system_root_image` but behave like so.

Since we can't reliably check the Android version through `ro.build.version.sdk` until we locate the system partition, then we only can check that the `/system/system` directory exists.

To avoid easy mistakes, a more specific `/system/system/build.prop` check has been implemented.

TEST BUILDS: https://github.com/WeAreFairphone/flashable-zip_microG/releases/tag/2020-04-07

Please, report if these pre-releases work for your Android 10 devices or other previous versions, with or without A/B system-as-root partitions layout. Tested succesfully with a OnePlus 3 @ LOS 17.1 and a Fairphone 2 @ LOS 15.1.